### PR TITLE
Remove hard-coded shebang in CGI script

### DIFF
--- a/cgi-bin/script.py
+++ b/cgi-bin/script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import cgi
 # cgitb allows us to view cgi errors, best to comment it out when using in production


### PR DESCRIPTION
Assuming that `python server.py` was run in the same environment as the
one virtualenv was installed and activated in, this shebang will always
work.

This frees the user (or "dev"?) from needing to change the shebang to a value specific to his/her machine.